### PR TITLE
Add library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,10 +8,9 @@
 # All rights reserved. Published under the BSD-2 license in the LICENSE file.
 ################################################################################
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.12)
 
-project(kagen)
-#set_target_properties(kagen PROPERTIES LINKER_LANGUAGE CXX)
+project(kagen LANGUAGES CXX)
 
 # prohibit in-source builds
 if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
@@ -268,6 +267,7 @@ endif()
 set(CGAL_DONT_OVERRIDE_CMAKE_FLAGS TRUE CACHE BOOL "Force CGAL to maintain CMAKE flags")
 find_package(CGAL)
 if(CGAL_FOUND)
+  add_definitions(-DKAGEN_CGAL_FOUND) 
   include(${CGAL_USE_FILE})
 else()
   message(STATUS "Could not find CGAL library")
@@ -308,10 +308,7 @@ endmacro(build_mpi_prog)
 
 ################################################################################
 
-# descend into library source
-# add_subdirectory(include)
-
-# descend into apps
 add_subdirectory(app)
+add_subdirectory(library)
 
 ################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,7 +270,7 @@ if(CGAL_FOUND)
   add_definitions(-DKAGEN_CGAL_FOUND) 
   include(${CGAL_USE_FILE})
 else()
-  message(STATUS "Could not find CGAL library")
+  message(STATUS "Could not find CGAL library: Random Delaunay Graphs will not be available")
 endif()
 
 # use sampling lib

--- a/app/interface_test.cpp
+++ b/app/interface_test.cpp
@@ -28,8 +28,10 @@ int main(int argn, char **argv) {
   gen.GenerateUndirectedGNM(num_vertices, num_edges);
   gen.Generate2DRGG(num_vertices, 0.0072);
   gen.Generate3DRGG(num_vertices, 0.01);
+#ifdef KAGEN_CGAL_FOUND
   gen.Generate2DRDG(num_vertices);
   gen.Generate3DRDG(num_vertices);
+#endif // KAGEN_CGAL_FOUND
   gen.GenerateRHG(num_vertices, 3.0, 16);
   gen.GenerateBA(num_vertices, 16);
   

--- a/app/kagen.cpp
+++ b/app/kagen.cpp
@@ -16,8 +16,11 @@
 #include "parse_parameters.h"
 #include "timer.h"
 
+#if KAGEN_CGAL_FOUND
 #include "geometric/delaunay/delaunay_2d.h"
 #include "geometric/delaunay/delaunay_3d.h"
+#endif // KAGEN_CGAL_FOUND
+
 #include "geometric/rgg/rgg_2d.h"
 #include "geometric/rgg/rgg_3d.h"
 #include "gnm/gnm_directed.h"
@@ -146,12 +149,14 @@ int main(int argn, char **argv) {
     else if (generator_config.generator == "rgg_3d")
       RunGenerator<RGG3D<decltype(edge_cb)>, decltype(edge_cb)>
         (generator_config, rank, size, stats, edge_stats, edges, edge_cb);
+#ifdef KAGEN_CGAL_FOUND
     else if (generator_config.generator == "rdg_2d")
       RunGenerator<Delaunay2D<decltype(edge_cb)>, decltype(edge_cb)>
         (generator_config, rank, size, stats, edge_stats, edges, edge_cb);
     else if (generator_config.generator == "rdg_3d")
       RunGenerator<Delaunay3D<decltype(edge_cb)>, decltype(edge_cb)>
         (generator_config, rank, size, stats, edge_stats, edges, edge_cb);
+#endif // KAGEN_CGAL_FOUND
     else if (generator_config.generator == "rhg")
       RunGenerator<Hyperbolic<decltype(edge_cb)>, decltype(edge_cb)>
         (generator_config, rank, size, stats, edge_stats, edges, edge_cb);

--- a/compile.sh
+++ b/compile.sh
@@ -6,6 +6,6 @@ git submodule update --init --recursive
 # Compile code
 mkdir build
 cd build
-cmake -DCMAKE_C_COMPILER=gcc-7 -DCMAKE_CXX_COMPILER=g++-7 ../
+cmake -DCMAKE_BUILD_TYPE=Release ../
 make -j4
 

--- a/include/generators/barabassi/barabassi.h
+++ b/include/generators/barabassi/barabassi.h
@@ -11,6 +11,8 @@
 
 #include <iostream>
 #include <vector>
+#include <iomanip>
+#include <cmath>
 
 #include "definitions.h"
 #include "generator_config.h"
@@ -34,7 +36,7 @@ class Barabassi {
     MPI_Comm_size(MPI_COMM_WORLD, &size);
 
     // Init variables
-    from_ = rank * ceil(config_.n / (LPFloat)size);
+    from_ = rank * std::ceil(config_.n / (LPFloat)size);
     to_ = std::min((SInt)((rank + 1) * ceil(config_.n / (LPFloat)size) - 1),
                    config_.n - 1);
     std::cout << "f " << from_ << " t " << to_ << std::endl;

--- a/include/generators/geometric/rgg/rgg_2d.h
+++ b/include/generators/geometric/rgg/rgg_2d.h
@@ -114,9 +114,9 @@ class RGG2D : public Geometric2D {
                          const SInt second_chunk_id,
                          const SInt second_cell_id) {
     // Check if vertices not generated
-    SInt first_global_cell_id = ComputeGlobalCellId(first_chunk_id, first_cell_id);
-    SInt second_global_cell_id =
-        ComputeGlobalCellId(second_chunk_id, second_cell_id);
+    //SInt first_global_cell_id = ComputeGlobalCellId(first_chunk_id, first_cell_id);
+    //SInt second_global_cell_id =
+    //    ComputeGlobalCellId(second_chunk_id, second_cell_id);
 
     // Gather vertices (temp)
     std::vector<Vertex> vertices_first;

--- a/include/generators/gnm/gnm_undirected.h
+++ b/include/generators/gnm/gnm_undirected.h
@@ -267,7 +267,7 @@ class GNMUndirected {
     SInt offset_row = OffsetInRow(row_id);
     SInt offset_column = OffsetInColumn(column_id);
     if (!config_.self_loops) offset_row += 1;
-    bool local_row = (offset_row >= start_node_ && offset_row < end_node_);
+    //bool local_row = (offset_row >= start_node_ && offset_row < end_node_);
 
     // Number edges
     SInt n_row = NodesInRow(row_id);

--- a/include/generators/gnp/gnp_undirected.h
+++ b/include/generators/gnp/gnp_undirected.h
@@ -137,7 +137,7 @@ class GNPUndirected {
       total_edges = row_n * (column_n - 1) / 2;
     else
       total_edges = row_n * (column_n + 1) / 2;
-    bool local_row = (offset_row >= start_node_ && offset_row < end_node_);
+    //bool local_row = (offset_row >= start_node_ && offset_row < end_node_);
 
     // Generate variate
     SInt h =

--- a/include/generators/grid/grid_2d.h
+++ b/include/generators/grid/grid_2d.h
@@ -154,14 +154,14 @@ class Grid2D {
 
   bool IsLocalVertex(const SInt local_row, const SInt local_col, 
                      const SInt rows, const SInt cols) {
-    if (local_row < 0 || local_row >= rows) return false;
-    if (local_col < 0 || local_col >= cols) return false;
+    if (local_row >= rows) return false;
+    if (local_col >= cols) return false;
     return true;
   }
 
   bool IsValidChunk(const SInt chunk_row, const SInt chunk_col) {
-    if (chunk_row < 0 || chunk_row >= chunks_per_dim_) return false;
-    if (chunk_col < 0 || chunk_col >= chunks_per_dim_) return false;
+    if (chunk_row >= chunks_per_dim_) return false;
+    if (chunk_col >= chunks_per_dim_) return false;
     return true;
   }
 

--- a/include/generators/grid/grid_3d.h
+++ b/include/generators/grid/grid_3d.h
@@ -167,16 +167,16 @@ class Grid3D {
 
   bool IsLocalVertex(const SSInt local_x, const SSInt local_y, const SSInt local_z,
                      const SInt xs, const SInt ys, const SInt zs) {
-    if (local_x < 0 || local_x >= xs) return false;
-    if (local_y < 0 || local_y >= ys) return false;
-    if (local_z < 0 || local_z >= zs) return false;
+    if (local_x < 0 || local_x >= static_cast<SSInt>(xs)) return false;
+    if (local_y < 0 || local_y >= static_cast<SSInt>(ys)) return false;
+    if (local_z < 0 || local_z >= static_cast<SSInt>(zs)) return false;
     return true;
   }
 
   bool IsValidChunk(const SSInt chunk_x, const SSInt chunk_y, const SSInt chunk_z) {
-    if (chunk_x < 0 || chunk_x >= chunks_per_dim_) return false;
-    if (chunk_y < 0 || chunk_y >= chunks_per_dim_) return false;
-    if (chunk_z < 0 || chunk_z >= chunks_per_dim_) return false;
+    if (chunk_x < 0 || chunk_x >= static_cast<SSInt>(chunks_per_dim_)) return false;
+    if (chunk_y < 0 || chunk_y >= static_cast<SSInt>(chunks_per_dim_)) return false;
+    if (chunk_z < 0 || chunk_z >= static_cast<SSInt>(chunks_per_dim_)) return false;
     return true;
   }
 
@@ -301,9 +301,9 @@ class Grid3D {
     SInt intersect_frontal_frontal_left = vertex_x * next_vertex_y * vertex_z;
     SInt intersect_all = vertex_x * vertex_y * vertex_z;
 
-    SInt offset = upper_cube + frontal_cube + frontal_left_cube 
-                    - (intersect_upper_frontal + intersect_upper_frontal_left + intersect_frontal_frontal_left)
-                    + intersect_all;
+    //SInt offset = upper_cube + frontal_cube + frontal_left_cube 
+    //                - (intersect_upper_frontal + intersect_upper_frontal_left + intersect_frontal_frontal_left)
+    //                + intersect_all;
 
     return upper_cube + frontal_cube + frontal_left_cube 
             - (intersect_upper_frontal + intersect_upper_frontal_left + intersect_frontal_frontal_left)

--- a/include/generators/hyperbolic/hyperbolic.h
+++ b/include/generators/hyperbolic/hyperbolic.h
@@ -326,7 +326,7 @@ class Hyperbolic {
       ComputeChunk(chunk_id);
       ComputeAnnuli(chunk_id);
     }
-    auto &chunk = chunks_[chunk_id];
+    //auto &chunk = chunks_[chunk_id];
     auto &annulus = annuli_[ComputeGlobalChunkId(annulus_id, chunk_id)];
 
     // Lazily compute cells distribution

--- a/include/generators/kronecker/utils.h
+++ b/include/generators/kronecker/utils.h
@@ -133,7 +133,7 @@ void * xcalloc (size_t n, size_t sz) {
   return out;
 }
 
-void xfree (void * p, size_t sz) {
+void xfree (void * p, size_t) {
   free (p);
 }
 #endif

--- a/include/io/generator_io.h
+++ b/include/io/generator_io.h
@@ -123,7 +123,7 @@ class GeneratorIO {
     if (rank == ROOT) {
       // Sort edges and remove duplicates
       std::sort(std::begin(edges), std::end(edges));
-      SInt total_edges = edges.size();
+      //SInt total_edges = edges.size();
       edges.erase(unique(edges.begin(), edges.end()), edges.end());
       
 #ifndef BINARY_OUT

--- a/include/tools/geometry.h
+++ b/include/tools/geometry.h
@@ -10,7 +10,10 @@
 #define _GEOMETRY_H_
 
 #include <cmath>
+
+#ifdef KAGEN_CGAL_FOUND
 #include <CGAL/Dimension.h>
+#endif // KAGEN_CGAL_FOUND
 
 namespace kagen {
 
@@ -153,6 +156,7 @@ class PGGeometry {
   }
 };
 
+#ifdef KAGEN_CGAL_FOUND
 /* Tests whehter a sphere intersects with the box */
 template <typename BOX, typename SPHERE>
 static bool boxIntersects(const BOX &box, const SPHERE &sphere) {
@@ -205,6 +209,6 @@ static bool boxContains(const BOX &box, const SPHERE &sphere) {
 
   return true;
 }
-
+#endif // KAGEN_CGAL_FOUND
 }
 #endif

--- a/interface/kagen_interface.h
+++ b/interface/kagen_interface.h
@@ -16,8 +16,11 @@
 #include "generator_config.h"
 #include "parse_parameters.h"
 
+#ifdef KAGEN_CGAL_FOUND
 #include "geometric/delaunay/delaunay_2d.h"
 #include "geometric/delaunay/delaunay_3d.h"
+#endif // KAGEN_CGAL_FOUND
+
 #include "geometric/rgg/rgg_2d.h"
 #include "geometric/rgg/rgg_3d.h"
 #include "gnm/gnm_directed.h"
@@ -215,6 +218,7 @@ class KaGen {
                          SInt k = 0, 
                          SInt seed = 1, 
                          const std::string &output = "out") {
+#ifdef KAGEN_CGAL_FOUND
     EdgeList edges; 
 
     // Update config
@@ -234,12 +238,16 @@ class KaGen {
 
     edges.insert(begin(edges), gen.GetVertexRange());
     return edges;
+#else // KAGEN_CGAL_FOUND
+    throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif // KAGEN_CGAL_FOUND
   }
 
   EdgeList Generate3DRDG(SInt n, 
                          SInt k = 0, 
                          SInt seed = 1, 
                          const std::string &output = "out") {
+#ifdef KAGEN_CGAL_FOUND
     EdgeList edges; 
 
     // Update config
@@ -259,6 +267,9 @@ class KaGen {
 
     edges.insert(begin(edges), gen.GetVertexRange());
     return edges;
+#else // KAGEN_CGAL_FOUND
+    throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif // KAGEN_CGAL_FOUND
   }
 
   EdgeList GenerateBA(SInt n, 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(kagen_library kagen_library.cc kagen_library.h)
+target_link_libraries(kagen_library PUBLIC ${KAGEN_LINK_LIBRARIES})
+target_include_directories(kagen_library PRIVATE ${KAGEN_INCLUDE_DIRS})
+target_include_directories(kagen_library PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_compile_features(kagen_library PUBLIC cxx_std_17)

--- a/library/kagen_library.cc
+++ b/library/kagen_library.cc
@@ -115,7 +115,6 @@ KaGenResult KaGen::GenerateUndirectedGNP(const SInt n, const LPFloat p, const SI
 
 KaGenResult KaGen::Generate2DRGG(const SInt n, const LPFloat r, const SInt k, const int seed,
                                  const std::string &output) {
-#ifdef KAGEN_CGAL_FOUND
   // Update config
   config_->n = n;
   config_->r = r;
@@ -134,14 +133,10 @@ KaGenResult KaGen::Generate2DRGG(const SInt n, const LPFloat r, const SInt k, co
   std::cout << "Range for PE " << rank_ << ": " << gen.GetVertexRange().first << " -- " << gen.GetVertexRange().second << std::endl;
   
   return {std::move(edges), gen.GetVertexRange()};
-#else 
-  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
-#endif 
 }
 
 KaGenResult KaGen::Generate3DRGG(const SInt n, const LPFloat r, const SInt k, const int seed,
                                  const std::string &output) {
-#ifdef KAGEN_CGAL_FOUND
   // Update config
   config_->n = n;
   config_->r = r;
@@ -158,12 +153,10 @@ KaGenResult KaGen::Generate3DRGG(const SInt n, const LPFloat r, const SInt k, co
   gen.Generate();
 
   return {std::move(edges), gen.GetVertexRange()};
-#else 
-  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
-#endif 
 }
 
 KaGenResult KaGen::Generate2DRDG(const SInt n, const SInt k, const int seed, const std::string &output) {
+#ifdef KAGEN_CGAL_FOUND
   // Update config
   config_->n = n;
   config_->k = (k == 0 ? config_->k : k);
@@ -179,9 +172,13 @@ KaGenResult KaGen::Generate2DRDG(const SInt n, const SInt k, const int seed, con
   gen.Generate();
 
   return {std::move(edges), gen.GetVertexRange()};
+#else 
+  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif 
 }
 
 KaGenResult KaGen::Generate3DRDG(const SInt n, const SInt k, const int seed, const std::string &output) {
+#ifdef KAGEN_CGAL_FOUND
   // Update config
   config_->n = n;
   config_->k = (k == 0 ? config_->k : k);
@@ -197,6 +194,9 @@ KaGenResult KaGen::Generate3DRDG(const SInt n, const SInt k, const int seed, con
   gen.Generate();
 
   return {std::move(edges), gen.GetVertexRange()};
+#else 
+  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif 
 }
 
 KaGenResult KaGen::GenerateBA(const SInt n, const SInt d, const SInt k, const int seed, const std::string &output) {

--- a/library/kagen_library.cc
+++ b/library/kagen_library.cc
@@ -1,0 +1,308 @@
+#include "kagen_library.h"
+
+#include "generator_config.h"
+
+#include "barabassi/barabassi.h"
+#include "geometric/rgg/rgg_2d.h"
+#include "geometric/rgg/rgg_3d.h"
+#include "gnm/gnm_directed.h"
+#include "gnm/gnm_undirected.h"
+#include "gnp/gnp_directed.h"
+#include "gnp/gnp_undirected.h"
+#include "grid/grid_2d.h"
+#include "hyperbolic/hyperbolic.h"
+#include "kronecker/kronecker.h"
+
+#ifdef KAGEN_CGAL_FOUND
+#include "geometric/delaunay/delaunay_2d.h"
+#include "geometric/delaunay/delaunay_3d.h"
+#endif 
+
+#include <iostream>
+
+namespace kagen::interface {
+KaGen::KaGen(const PEID rank, const PEID size)
+    : rank_(rank), size_(size), config_(std::make_unique<PGeneratorConfig>()) {
+  SetDefaults();
+}
+
+KaGen::~KaGen() = default;
+  
+
+KaGenResult KaGen::GenerateDirectedGMM(const SInt n, const SInt m, const SInt k, const int seed,
+                                       const std::string &output, const bool self_loops) {
+  // Update config
+  config_->n = n;
+  config_->m = m;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed= seed;
+  config_->output_file = output;
+  config_->self_loops = self_loops;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  GNMDirected<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateUndirectedGNM(const SInt n, const SInt m, const SInt k, const int seed,
+                                         const std::string &output, const bool self_loops) {
+  // Update config
+  config_->n = n;
+  config_->m = m;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+  config_->self_loops = self_loops;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  GNMUndirected<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateDirectedGNP(const SInt n, const LPFloat p, const SInt k, const int seed,
+                                       const std::string &output, const bool self_loops) {
+  // Update config
+  config_->n = n;
+  config_->p = p;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+  config_->self_loops = self_loops;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  GNPDirected<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateUndirectedGNP(const SInt n, const LPFloat p, const SInt k, const int seed,
+                                         const std::string &output, const bool self_loops) {
+  // Update config
+  config_->n = n;
+  config_->p = p;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+  config_->self_loops = self_loops;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  GNPUndirected<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::Generate2DRGG(const SInt n, const LPFloat r, const SInt k, const int seed,
+                                 const std::string &output) {
+#ifdef KAGEN_CGAL_FOUND
+  // Update config
+  config_->n = n;
+  config_->r = r;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  RGG2D<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  std::cout << "Range for PE " << rank_ << ": " << gen.GetVertexRange().first << " -- " << gen.GetVertexRange().second << std::endl;
+  
+  return {std::move(edges), gen.GetVertexRange()};
+#else 
+  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif 
+}
+
+KaGenResult KaGen::Generate3DRGG(const SInt n, const LPFloat r, const SInt k, const int seed,
+                                 const std::string &output) {
+#ifdef KAGEN_CGAL_FOUND
+  // Update config
+  config_->n = n;
+  config_->r = r;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  RGG3D<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+#else 
+  throw std::runtime_error("Library was compiled without CGAL. Thus, delaunay generators are not available.");
+#endif 
+}
+
+KaGenResult KaGen::Generate2DRDG(const SInt n, const SInt k, const int seed, const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  Delaunay2D<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::Generate3DRDG(const SInt n, const SInt k, const int seed, const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  Delaunay3D<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateBA(const SInt n, const SInt d, const SInt k, const int seed, const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->min_degree = d;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  Barabassi<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateRHG(const SInt n, const LPFloat gamma, const SInt d, const SInt k, const int seed,
+                               const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->plexp = gamma;
+  config_->avg_degree = d;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+
+  // Init and run generator
+  Hyperbolic<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::Generate2DGrid(const SInt n, const SInt m, const LPFloat p, const SInt periodic, const SInt k,
+                                  const int seed, const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->m = m;
+  config_->p = p;
+  config_->periodic = periodic;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  Grid2D<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+KaGenResult KaGen::GenerateKronecker(const SInt n, const SInt m, const SInt k,
+                                  const int seed, const std::string &output) {
+  // Update config
+  config_->n = n;
+  config_->m = m;
+  config_->k = (k == 0 ? config_->k : k);
+  config_->seed = seed;
+  config_->output_file = output;
+
+  // Edge callback
+  EdgeList edges;
+  auto edge_cb = [&](SInt source, SInt target) { edges.emplace_back(source, target); };
+
+  // Init and run generator
+  Kronecker<decltype(edge_cb)> gen(*config_, rank_, edge_cb);
+  gen.Generate();
+
+  return {std::move(edges), gen.GetVertexRange()};
+}
+
+void KaGen::SetDefaults() {
+  config_->n = 100;
+  config_->m = 0;
+  config_->k = size_;
+  config_->seed = 1;
+  config_->hash_sample = false;
+  config_->use_binom = false;
+  config_->output_file = "out";
+  config_->debug_output = "dbg";
+  config_->dist_size = 10;
+  config_->p = 0.0;
+  config_->self_loops = false;
+  config_->r = 0.125;
+  config_->avg_degree = 5.0;
+  config_->plexp = 2.6;
+  config_->thres = 0;
+  config_->query_both = true;
+  config_->min_degree = 4;
+  config_->precision = 32;
+  config_->base_size = (SInt)1 << 8;
+  config_->hyp_base = (SInt)1 << 8;
+  config_->iterations = 1;
+}
+} // namespace kagen::interface 

--- a/library/kagen_library.h
+++ b/library/kagen_library.h
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ interface/kagen_interface.h
+ *
+ * Copyright (C) 2016-2017 Sebastian Lamm <lamm@ira.uka.de>
+ *
+ * All rights reserved. Published under the BSD-2 license in the LICENSE file.
+ ******************************************************************************/
+
+#ifndef _KAGEN_LIBRARY_H_
+#define _KAGEN_LIBRARY_H_
+
+#include <memory>
+#include <utility>
+#include <vector>
+#include <string>
+
+namespace kagen {
+struct PGeneratorConfig;
+}
+
+namespace kagen::interface {
+using SInt = unsigned long long;
+using SSInt = long long;
+using EdgeList = std::vector<std::pair<SInt, SInt>>;
+using PEID = int;
+using HPFloat = long double;
+using LPFloat = double;
+
+struct KaGenResult {
+  EdgeList edges;
+  std::pair<SInt, SInt> vertex_range;
+};
+
+class KaGen {
+public:
+  KaGen(PEID rank, PEID size);
+  ~KaGen();
+
+  KaGenResult GenerateDirectedGMM(SInt n, SInt m, SInt k = 0, int seed = 1, const std::string &output = "out",
+                                  bool self_loops = false);
+
+  KaGenResult GenerateUndirectedGNM(SInt n, SInt m, SInt k = 0, int seed = 1, const std::string &output = "out",
+                                    bool self_loops = false);
+
+  KaGenResult GenerateDirectedGNP(SInt n, LPFloat p, SInt k = 0, int seed = 1, const std::string &output = "out",
+                                  bool self_loops = false);
+
+  KaGenResult GenerateUndirectedGNP(SInt n, LPFloat p, SInt k = 0, int seed = 1, const std::string &output = "out",
+                                    bool self_loops = false);
+
+  KaGenResult Generate2DRGG(SInt n, LPFloat r, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult Generate3DRGG(SInt n, LPFloat r, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult Generate2DRDG(SInt n, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult Generate3DRDG(SInt n, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult GenerateBA(SInt n, SInt d, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult GenerateRHG(SInt n, LPFloat gamma, SInt d, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+  KaGenResult Generate2DGrid(SInt n, SInt m, LPFloat p, SInt periodic, SInt k = 0, int seed = 1,
+                             const std::string &output = "out");
+
+  KaGenResult GenerateKronecker(SInt n, SInt m, SInt k = 0, int seed = 1, const std::string &output = "out");
+
+private:
+  void SetDefaults();
+
+  PEID rank_, size_;
+  std::unique_ptr<PGeneratorConfig> config_;
+};
+} // namespace kagen::interface
+
+#endif


### PR DESCRIPTION
Based on #10 

Including KaGen as header-only library can yield file name conflicts since KaGen does not prefix its includes with a unique directory name. 
This PR adds a library target `kagen_library` that allows KaGen to be used like a normal static / shared library. 