### PR TITLE
Add options string to C interface, binary 

### DIFF
--- a/app/KaGen.cpp
+++ b/app/KaGen.cpp
@@ -137,6 +137,14 @@ void SetupCommandLineArguments(CLI::App& app, PGeneratorConfig& config) {
     app.add_option("-k,--num-chunks", config.k, "Number of chunks used for graph generation");
     app.add_flag("-C,--coordinates", config.coordinates, "Generate coordinates (geometric generators only)");
 
+    { // Options string
+        auto* cmd = app.add_subcommand(
+            "options",
+            "Generate graph as specified by an options string; see library documentation for further details");
+        cmd->add_option_function<std::string>(
+            "options", [&config](const std::string& options) { config = CreateConfigFromString(options, config); });
+    }
+
     { // GNM_DIRECTED
         auto* cmd =
             app.add_subcommand("gnm-directed", "Directed Erdos-Renyi Graph")->alias("gnm_directed")->callback([&] {

--- a/app/KaGen.cpp
+++ b/app/KaGen.cpp
@@ -142,7 +142,8 @@ void SetupCommandLineArguments(CLI::App& app, PGeneratorConfig& config) {
             "options",
             "Generate graph as specified by an options string; see library documentation for further details");
         cmd->add_option_function<std::string>(
-            "options", [&config](const std::string& options) { config = CreateConfigFromString(options, config); });
+               "options", [&config](const std::string& options) { config = CreateConfigFromString(options, config); })
+            ->required();
     }
 
     { // GNM_DIRECTED

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,3 +13,6 @@ target_link_libraries(example_c_rgg2d PRIVATE KaGen::cKaGen)
 add_executable(example_options_string options_string_example.cc)
 target_link_libraries(example_options_string PRIVATE KaGen::KaGen)
 
+add_executable(example_c_options_string options_string_c_example.c)
+target_link_libraries(example_c_options_string PRIVATE KaGen::cKaGen)
+

--- a/examples/options_string_c_example.c
+++ b/examples/options_string_c_example.c
@@ -1,0 +1,28 @@
+#include <ckagen.h>
+#include <stdio.h>
+
+#include <mpi.h>
+
+int main(int argc, char* argv[]) {
+    MPI_Init(&argc, &argv);
+    kagen_t*        gen    = kagen_create(MPI_COMM_WORLD);
+    kagen_result_t* result = kagen_generate_from_option_string(gen, "rgg2d;n=16;m=32");
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    unsigned long long from, to;
+    kagen_result_vertex_range(result, &from, &to);
+    printf("On PE %d [%lld, %lld): ", rank, from, to);
+    size_t        nedges;
+    kagen_edge_t* current_edge = kagen_result_edge_list(result, &nedges);
+    for (unsigned i = 0; i < nedges; i++) {
+        printf("%lld->%lld ", current_edge->source, current_edge->target);
+        current_edge++;
+    }
+    printf("\n");
+
+    kagen_result_free(result);
+    kagen_free(gen);
+    return MPI_Finalize();
+}

--- a/examples/options_string_example.cc
+++ b/examples/options_string_example.cc
@@ -11,7 +11,7 @@ int main(int argc, char* argv[]) {
     kagen::KaGen generator(MPI_COMM_WORLD);
 
     // Generate a RGG2D graph with 16 nodes and 32 edges
-    const auto [edges, range] = generator.GenerateFromOptionString("type=rgg2d;n=16;m=32");
+    const auto [edges, range] = generator.GenerateFromOptionString("rgg2d;n=16;m=32");
 
     int rank;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/kagen/context.h
+++ b/kagen/context.h
@@ -125,4 +125,6 @@ struct PGeneratorConfig {
 };
 
 std::ostream& operator<<(std::ostream& out, const PGeneratorConfig& config);
+
+PGeneratorConfig CreateConfigFromString(const std::string& options_str, PGeneratorConfig config = {});
 } // namespace kagen

--- a/library/ckagen.cpp
+++ b/library/ckagen.cpp
@@ -72,6 +72,14 @@ void kagen_set_numer_of_chunks(kagen_t* gen, unsigned long long k) {
     gen->gen_ptr->SetNumberOfChunks(k);
 }
 
+kagen_result_t* kagen_generate_from_option_string(kagen_t* gen, const char* options) {
+    auto result = gen->gen_ptr->GenerateFromOptionString(options);
+
+    kagen_result_t* result_wrapper = new kagen_result_t;
+    result_wrapper->result_ptr     = new kagen::KaGenResult(std::move(result));
+    return result_wrapper;
+}
+
 kagen_result_t* kagen_generate_directed_gnm(kagen_t* gen, unsigned long long n, unsigned long long m, bool self_loops) {
     auto result = gen->gen_ptr->GenerateDirectedGNM(n, m, self_loops);
 

--- a/library/ckagen.h
+++ b/library/ckagen.h
@@ -32,6 +32,8 @@ void kagen_enable_output(kagen_t* gen, bool header);
 void kagen_use_hp_floats(kagen_t* gen, bool state);
 void kagen_set_numer_of_chunks(kagen_t* gen, unsigned long long k);
 
+kagen_result_t* kagen_generate_from_option_string(kagen_t* gen, const char* options);
+
 kagen_result_t* kagen_generate_directed_gnm(kagen_t* gen, unsigned long long n, unsigned long long m, bool self_loops);
 kagen_result_t*
 kagen_generate_undirected_gnm(kagen_t* gen, unsigned long long n, unsigned long long m, bool self_loops);

--- a/library/kagen.cpp
+++ b/library/kagen.cpp
@@ -52,71 +52,8 @@ void KaGen::SetNumberOfChunks(const SInt k) {
 }
 
 namespace {
-using Options = std::unordered_map<std::string, std::string>;
-
-// Parse a string such as 'key1=value1;key2=value2;key3;key4'
-Options ParseOptionString(const std::string& options) {
-    std::istringstream toker(options);
-    std::string        pair;
-    Options            result;
-
-    while (std::getline(toker, pair, ';')) {
-        const auto eq_pos = pair.find('=');
-        if (eq_pos == std::string::npos) { // No equal sign -> Option is a flag
-            result[pair] = "1";
-        } else {
-            const std::string key   = pair.substr(0, eq_pos);
-            const std::string value = pair.substr(eq_pos + 1);
-            result[key]             = value;
-        }
-    }
-
-    return result;
-}
-
-auto GenericGenerateFromOptionString(const std::string& options_str, PGeneratorConfig& config, MPI_Comm comm) {
-    auto options = ParseOptionString(options_str);
-
-    const std::string type_str = options["type"];
-    const auto        type_map = GetGeneratorTypeMap();
-    const auto        type_it  = type_map.find(type_str);
-    if (type_it == type_map.end()) {
-        throw std::runtime_error("invalid generator type");
-    }
-
-    auto get_sint_or_default = [&](const std::string& option, const SInt default_value = 0) {
-        const auto it = options.find(option);
-        return (it == options.end() ? default_value : std::stoll(it->second));
-    };
-    auto get_hpfloat_or_default = [&](const std::string& option, const HPFloat default_value = 0.0) {
-        const auto it = options.find(option);
-        return (it == options.end() ? default_value : std::stod(it->second));
-    };
-    auto get_bool_or_default = [&](const std::string& option, const bool default_value = false) {
-        const auto it = options.find(option);
-        return (
-            it == options.end() ? default_value : (it->second == "1" || it->second == "true" || it->second == "yes"));
-    };
-
-    config.generator   = type_it->second;
-    config.n           = get_sint_or_default("n", 1ull << get_sint_or_default("N"));
-    config.m           = get_sint_or_default("m", 1ull << get_sint_or_default("M"));
-    config.k           = get_sint_or_default("k");
-    config.p           = get_hpfloat_or_default("prob");
-    config.r           = get_hpfloat_or_default("radius");
-    config.plexp       = get_hpfloat_or_default("gamma");
-    config.periodic    = get_bool_or_default("periodic");
-    config.avg_degree  = get_hpfloat_or_default("avg_degree");
-    config.min_degree  = get_sint_or_default("min_degree");
-    config.grid_x      = get_sint_or_default("grid_x");
-    config.grid_y      = get_sint_or_default("grid_y");
-    config.grid_z      = get_sint_or_default("grid_z");
-    config.rmat_a      = get_sint_or_default("rmat_a");
-    config.rmat_b      = get_sint_or_default("rmat_b");
-    config.rmat_c      = get_sint_or_default("rmat_c");
-    config.coordinates = get_bool_or_default("coordinates");
-
-    return Generate(config, comm);
+auto GenericGenerateFromOptionString(const std::string& options_str, PGeneratorConfig base_config, MPI_Comm comm) {
+    return Generate(CreateConfigFromString(options_str, base_config), comm);
 }
 } // namespace
 

--- a/library/kagen.h
+++ b/library/kagen.h
@@ -76,11 +76,9 @@ public:
     KaGen(MPI_Comm comm);
 
     KaGen(const KaGen&) = delete;
-
     KaGen(KaGen&&) noexcept;
 
     KaGen& operator=(const KaGen&) = delete;
-
     KaGen& operator=(KaGen&&) noexcept;
 
     ~KaGen();
@@ -131,24 +129,26 @@ public:
     void SetNumberOfChunks(SInt k);
 
     /*!
-     * Generates a graph with options given by a string of options in key=value format:
-     * `key1=value1;key2=value2;key3;...`.
+     * Generates a graph with options given by a string of options in `key=value` or `flag` format:
+     * `key1=value1;flag1;...`.
      *
-     * Option keys are:
-     * - type=<gnm_undirected|
-     *         gnm_directed|
-     *         gnp_undirected|
-     *         gnp_directed|
-     *         rgg2d|
-     *         rgg3d|
-     *         grid2d|
-     *         grid3d|
-     *         rdg2d|
-     *         rdg3d|
-     *         rhg|
-     *         ba|
-     *         kronecker|
-     *         rmat>
+     * Use one of the following flags to select a graph model:
+     * - gnm_undirected
+     * - gnm_directed
+     * - gnp_undirected
+     * - gnp_directed
+     * - rgg2d
+     * - rgg3d
+     * - grid2d
+     * - grid3d
+     * - rdg2d
+     * - rdg3d
+     * - rhg
+     * - ba
+     * - kronecker
+     * - rmat
+     *
+     * Use the following keys to specify generator properties:
      * - n=<SInt>             -- number of nodes
      * - N=<SInt>             -- number of nodes as a power of 2
      * - m=<SInt>             -- number of edges
@@ -168,7 +168,7 @@ public:
      * - periodic[=0|1]       -- periodic boundary condition (various generators)
      *
      * Depending on the selected generator type, some options are mandatory, some are optional and some are ignored.
-     * The following example generates a RGG2D graph with 100 nodes and 200 edges: `type=rgg2d;n=100;m=200`.
+     * The following example generates a RGG2D graph with 100 nodes and 200 edges: `rgg2d;n=100;m=200`.
      *
      * @type options Options string with key=value pairs.
      * @return The generated graph.
@@ -343,3 +343,4 @@ KaGenResultCSR<IDX> BuildCSR(Graph graph) {
     return csr;
 }
 } // namespace kagen
+


### PR DESCRIPTION
Adds `kagen_generate_from_option_string()` (same as `KaGen::GenerateFromOptionString()`) to the C interface. 

Adds the same functionality to the binary: `./KaGen options "rgg2d;N=10;M=12"`

Allows the generator type to be specified without `type=` prefix 