### PR TITLE
Refactoring/simplify generator usage

### DIFF
--- a/kagen/facade.cpp
+++ b/kagen/facade.cpp
@@ -128,18 +128,15 @@ std::tuple<EdgeList, VertexRange, Coordinates> Generate(const PGeneratorConfig& 
 
     auto generator = factory->Create(config, rank, size);
     generator->Generate();
-    auto edges        = generator->TakeEdges();
-    auto vertex_range = generator->GetVertexRange();
-    auto coordinates  = generator->GetCoordinates();
 
-    const SInt num_edges_before_finalize = edges.size();
+    const SInt num_edges_before_finalize = generator->GetEdges().size();
     if (!config.skip_postprocessing) {
         if (output_info) {
             std::cout << "Finalizing ..." << std::endl;
         }
         generator->Finalize(comm);
     }
-    const SInt num_edges_after_finalize = edges.size();
+    const SInt num_edges_after_finalize = generator->GetEdges().size();
 
     const auto end_graphgen = MPI_Wtime();
 
@@ -156,6 +153,10 @@ std::tuple<EdgeList, VertexRange, Coordinates> Generate(const PGeneratorConfig& 
                       << std::endl;
         }
     }
+
+    auto edges        = generator->TakeEdges();
+    auto vertex_range = generator->GetVertexRange();
+    auto coordinates  = generator->GetCoordinates();
 
     // Validation
     if (config.validate_simple_graph) {

--- a/kagen/facade.cpp
+++ b/kagen/facade.cpp
@@ -82,58 +82,6 @@ std::unique_ptr<GeneratorFactory> CreateGeneratorFactory(const GeneratorType typ
 }
 
 namespace {
-bool IsPowerOfTwo(const SInt value) {
-    return (value & (value - 1)) == 0;
-}
-
-bool IsSquare(const SInt value) {
-    const SInt root = std::round(std::sqrt(value));
-    return root * root == value;
-}
-
-bool IsCubic(const SInt value) {
-    const SInt root = std::round(std::cbrt(value));
-    return root * root * root == value;
-}
-
-SInt FindMultipleSquare(const SInt value) {
-    if (IsSquare(value)) {
-        return value;
-    }
-    if (IsPowerOfTwo(value)) {
-        return 2 * value; // every 2nd power of two is square
-    }
-
-    // find smallest square number that is a multiple of value
-    const SInt root = std::sqrt(value);
-    for (SInt cur = root; cur < value; ++cur) {
-        const SInt squared = cur * cur;
-        if (squared % value == 0) {
-            return squared;
-        }
-    }
-    return value * value;
-}
-
-SInt FindMultipleCube(const SInt value) {
-    if (IsCubic(value)) {
-        return value;
-    }
-    if (IsPowerOfTwo(value)) {
-        return IsCubic(value * 2) ? value * 2 : value * 4;
-    }
-
-    // find smallest cubic number that is a multiple of value
-    const SInt root = std::cbrt(value);
-    for (SInt cur = root; cur < value; ++cur) {
-        const SInt cubed = cur * cur * cur;
-        if (cubed % value == 0) {
-            return cubed;
-        }
-    }
-    return value * value * value;
-}
-
 void PrintHeader(const PGeneratorConfig& config) {
     std::cout << "###############################################################################\n";
     std::cout << "#                         _  __      ____                                     #\n";
@@ -163,59 +111,10 @@ std::tuple<EdgeList, VertexRange, Coordinates> Generate(const PGeneratorConfig& 
     auto             factory = CreateGeneratorFactory(config_template.generator);
     PGeneratorConfig config;
     try {
-        config = factory->NormalizeParameters(config_template, output_info);
+        config = factory->NormalizeParameters(config_template, size, output_info);
     } catch (ConfigurationError& ex) {
         if (output_error) {
             std::cerr << "Error: " << ex.what() << "\n";
-        }
-        std::exit(1);
-    }
-
-    // Get generator requirements
-    const int  requirements                      = factory->Requirements();
-    const bool require_power_of_two_communicator = requirements & GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE;
-    const bool require_square_chunks             = requirements & GeneratorRequirement::SQUARE_CHUNKS;
-    const bool require_cubic_chunks              = requirements & GeneratorRequirement::CUBIC_CHUNKS;
-    const bool require_one_chunk_per_pe          = requirements & GeneratorRequirement::ONE_CHUNK_PER_PE;
-
-    // Validate number of PEs
-    if (require_power_of_two_communicator && !IsPowerOfTwo(size)) {
-        if (output_error) {
-            std::cerr << "Error: generator requires the number of PEs to be a power of two\n";
-        }
-        std::exit(1);
-    }
-
-    // Setup chunk count
-    if (config.k == 0) { // automatic selection
-        if (require_square_chunks) {
-            config.k = FindMultipleSquare(size);
-        } else if (require_cubic_chunks) {
-            config.k = FindMultipleCube(size);
-        } else {
-            config.k = size;
-        }
-
-        if (output_info) {
-            std::cout << "Setting number of chunks to " << config.k << std::endl;
-        }
-    } else { // only validation
-        if (require_square_chunks && !IsSquare(config.k)) {
-            if (output_error) {
-                std::cerr << "Error: generator requires a square number of chunks\n";
-            }
-            std::exit(1);
-        }
-        if (require_cubic_chunks && !IsCubic(config.k)) {
-            if (output_error) {
-                std::cerr << "Error: generator requires a cubic number of chunks\n";
-            }
-            std::exit(1);
-        }
-    }
-    if (require_one_chunk_per_pe && config.k != static_cast<SInt>(size)) {
-        if (output_error) {
-            std::cerr << "Error: generator requires exactly one chunk per PE\n";
         }
         std::exit(1);
     }

--- a/kagen/generators/barabassi/barabassi.cpp
+++ b/kagen/generators/barabassi/barabassi.cpp
@@ -9,7 +9,12 @@
 #include "kagen/generators/generator.h"
 
 namespace kagen {
-PGeneratorConfig BarabassiFactory::NormalizeParameters(PGeneratorConfig config, bool output) const {
+PGeneratorConfig
+BarabassiFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    if (config.k == 0) {
+        config.k = static_cast<SInt>(size);
+    }
+
     if (config.min_degree == 0) {
         if (config.n == 0 || config.m == 0) {
             throw ConfigurationError("at least two parameters out of {n, m, d} must be nonzero");

--- a/kagen/generators/barabassi/barabassi.cpp
+++ b/kagen/generators/barabassi/barabassi.cpp
@@ -7,6 +7,7 @@
 
 #include "kagen/generators/barabassi/barabassi.h"
 #include "kagen/generators/generator.h"
+#include "kagen/tools/postprocessor.h"
 
 namespace kagen {
 PGeneratorConfig
@@ -51,10 +52,10 @@ Barabassi::Barabassi(const PGeneratorConfig& config, const PEID rank, const PEID
     to_   = std::min((SInt)((rank + 1) * std::ceil(config_.n / (LPFloat)size) - 1), config_.n - 1);
 }
 
-bool Barabassi::IsAlmostUndirected() const {
-    // If we do not want a directed graph, we want an undirected graph
-    // Since the generator does not always generate reverse edges across PEs, we are 'almost' undirected
-    return !config_.directed;
+void Barabassi::Finalize(MPI_Comm comm) {
+    if (!config_.directed) {
+        AddReverseEdges(edges_, vertex_range_, comm);
+    }
 }
 
 void Barabassi::GenerateImpl() {

--- a/kagen/generators/barabassi/barabassi.h
+++ b/kagen/generators/barabassi/barabassi.h
@@ -14,7 +14,7 @@
 namespace kagen {
 class BarabassiFactory : public GeneratorFactory {
 public:
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/barabassi/barabassi.h
+++ b/kagen/generators/barabassi/barabassi.h
@@ -11,6 +11,8 @@
 #include "kagen/definitions.h"
 #include "kagen/generators/generator.h"
 
+#include <mpi.h>
+
 namespace kagen {
 class BarabassiFactory : public GeneratorFactory {
 public:
@@ -23,7 +25,7 @@ class Barabassi : public Generator {
 public:
     Barabassi(const PGeneratorConfig& config, PEID rank, PEID size);
 
-    bool IsAlmostUndirected() const override;
+    void Finalize(MPI_Comm comm) final;
 
 protected:
     void GenerateImpl() override;

--- a/kagen/generators/generator.cpp
+++ b/kagen/generators/generator.cpp
@@ -2,15 +2,13 @@
 #include "kagen/context.h"
 #include "kagen/definitions.h"
 
+#include <mpi.h>
+
 #include <algorithm>
 #include <cmath>
 
 namespace kagen {
 Generator::~Generator() = default;
-
-bool Generator::IsAlmostUndirected() const {
-    return false;
-}
 
 void Generator::Generate() {
     edges_.clear();
@@ -18,6 +16,8 @@ void Generator::Generate() {
     coordinates_.second.clear();
     GenerateImpl();
 }
+
+void Generator::Finalize(MPI_Comm) {}
 
 const EdgeList& Generator::GetEdges() const {
     return edges_;

--- a/kagen/generators/generator.cpp
+++ b/kagen/generators/generator.cpp
@@ -3,6 +3,7 @@
 #include "kagen/definitions.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace kagen {
 Generator::~Generator() = default;
@@ -50,11 +51,92 @@ void Generator::FilterDuplicateEdges() {
 
 GeneratorFactory::~GeneratorFactory() = default;
 
-int GeneratorFactory::Requirements() const {
-    return GeneratorRequirement::NONE;
+PGeneratorConfig GeneratorFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, bool) const {
+    if (config.k == 0) {
+        config.k = static_cast<SInt>(size);
+    }
+    return config;
 }
 
-PGeneratorConfig GeneratorFactory::NormalizeParameters(const PGeneratorConfig config, bool) const {
-    return config;
+namespace {
+bool IsPowerOfTwo(const SInt value) {
+    return (value & (value - 1)) == 0;
+}
+
+bool IsSquare(const SInt value) {
+    const SInt root = std::round(std::sqrt(value));
+    return root * root == value;
+}
+
+bool IsCubic(const SInt value) {
+    const SInt root = std::round(std::cbrt(value));
+    return root * root * root == value;
+}
+
+SInt FindSquareMultipleOf(const SInt value) {
+    if (IsSquare(value)) {
+        return value;
+    }
+    if (IsPowerOfTwo(value)) {
+        return 2 * value; // every 2nd power of two is square
+    }
+
+    // find smallest square number that is a multiple of value
+    const SInt root = std::sqrt(value);
+    for (SInt cur = root; cur < value; ++cur) {
+        const SInt squared = cur * cur;
+        if (squared % value == 0) {
+            return squared;
+        }
+    }
+    return value * value;
+}
+
+SInt FindCubeMultipleOf(const SInt value) {
+    if (IsCubic(value)) {
+        return value;
+    }
+    if (IsPowerOfTwo(value)) {
+        return IsCubic(value * 2) ? value * 2 : value * 4;
+    }
+
+    // find smallest cubic number that is a multiple of value
+    const SInt root = std::cbrt(value);
+    for (SInt cur = root; cur < value; ++cur) {
+        const SInt cubed = cur * cur * cur;
+        if (cubed % value == 0) {
+            return cubed;
+        }
+    }
+    return value * value * value;
+}
+} // namespace
+
+void GeneratorFactory::EnsurePowerOfTwoCommunicatorSize(PGeneratorConfig&, const PEID size) const {
+    if (!IsPowerOfTwo(size)) {
+        throw ConfigurationError("number of PEs must be a power of two");
+    }
+}
+
+void GeneratorFactory::EnsureSquareChunkSize(PGeneratorConfig& config, const PEID size) const {
+    if (config.k == 0) {
+        config.k = FindSquareMultipleOf(size);
+    } else if (!IsSquare(config.k)) {
+        throw ConfigurationError("number of chunks must be square");
+    }
+}
+
+void GeneratorFactory::EnsureCubicChunkSize(PGeneratorConfig& config, const PEID size) const {
+    if (config.k == 0) {
+        config.k = FindCubeMultipleOf(size);
+    } else if (!IsCubic(config.k)) {
+        throw ConfigurationError("number of chunks must be cubic");
+    }
+}
+
+void GeneratorFactory::EnsureOneChunkPerPE(PGeneratorConfig& config, const PEID size) const {
+    if (config.k != static_cast<SInt>(size)) {
+        throw ConfigurationError("number of chunks must match the number of PEs");
+    }
 }
 } // namespace kagen

--- a/kagen/generators/generator.h
+++ b/kagen/generators/generator.h
@@ -8,14 +8,6 @@
 #include "kagen/definitions.h"
 
 namespace kagen {
-enum GeneratorRequirement {
-    NONE                           = 0,
-    POWER_OF_TWO_COMMUNICATOR_SIZE = 1 << 0,
-    SQUARE_CHUNKS                  = 1 << 1,
-    CUBIC_CHUNKS                   = 1 << 2,
-    ONE_CHUNK_PER_PE               = 1 << 3,
-};
-
 class Generator {
 public:
     virtual ~Generator();
@@ -79,10 +71,14 @@ class GeneratorFactory {
 public:
     virtual ~GeneratorFactory();
 
-    virtual int Requirements() const;
-
-    virtual PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const;
+    virtual PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const;
 
     virtual std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const = 0;
+
+protected:
+    void EnsurePowerOfTwoCommunicatorSize(PGeneratorConfig& config, PEID size) const;
+    void EnsureSquareChunkSize(PGeneratorConfig& config, PEID size) const;
+    void EnsureCubicChunkSize(PGeneratorConfig& config, PEID size) const;
+    void EnsureOneChunkPerPE(PGeneratorConfig& config, PEID size) const;
 };
 } // namespace kagen

--- a/kagen/generators/generator.h
+++ b/kagen/generators/generator.h
@@ -4,6 +4,8 @@
 #include <exception>
 #include <memory>
 
+#include <mpi.h>
+
 #include "kagen/context.h"
 #include "kagen/definitions.h"
 
@@ -12,9 +14,9 @@ class Generator {
 public:
     virtual ~Generator();
 
-    virtual bool IsAlmostUndirected() const;
-
     void Generate();
+
+    virtual void Finalize(MPI_Comm comm);
 
     const EdgeList& GetEdges() const;
 
@@ -49,7 +51,6 @@ protected:
 
     void FilterDuplicateEdges();
 
-private:
     EdgeList    edges_;
     VertexRange vertex_range_;
     Coordinates coordinates_;

--- a/kagen/generators/geometric/delaunay.cpp
+++ b/kagen/generators/geometric/delaunay.cpp
@@ -17,13 +17,12 @@ PGeneratorConfig NormalizeParametersCommon(PGeneratorConfig config, const double
     return config;
 }
 } // namespace
+PGeneratorConfig
+Delaunay2DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureSquareChunkSize(config, size);
+    EnsurePowerOfTwoCommunicatorSize(config, size);
+    EnsureOneChunkPerPE(config, size);
 
-int Delaunay2DFactory::Requirements() const {
-    return GeneratorRequirement::SQUARE_CHUNKS | GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE
-           | GeneratorRequirement::ONE_CHUNK_PER_PE;
-}
-
-PGeneratorConfig Delaunay2DFactory::NormalizeParameters(PGeneratorConfig config, const bool output) const {
     return NormalizeParametersCommon(config, 3, output);
 }
 
@@ -32,11 +31,11 @@ Delaunay2DFactory::Create(const PGeneratorConfig& config, const PEID rank, const
     return std::make_unique<Delaunay2D>(config, rank, size);
 }
 
-int Delaunay3DFactory::Requirements() const {
-    return GeneratorRequirement::CUBIC_CHUNKS | GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE;
-}
+PGeneratorConfig
+Delaunay3DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureCubicChunkSize(config, size);
+    EnsurePowerOfTwoCommunicatorSize(config, size);
 
-PGeneratorConfig Delaunay3DFactory::NormalizeParameters(PGeneratorConfig config, const bool output) const {
     return NormalizeParametersCommon(config, 15.53 / 2.0, output);
 }
 

--- a/kagen/generators/geometric/delaunay.h
+++ b/kagen/generators/geometric/delaunay.h
@@ -7,18 +7,14 @@
 namespace kagen {
 class Delaunay2DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };
 
 class Delaunay3DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/geometric/delaunay/delaunay_2d.cpp
+++ b/kagen/generators/geometric/delaunay/delaunay_2d.cpp
@@ -41,10 +41,6 @@ Delaunay2D::Delaunay2D(const PGeneratorConfig& config, const PEID rank, const PE
     InitDatastructures();
 }
 
-bool Delaunay2D::IsAlmostUndirected() const {
-    return true;
-}
-
 void Delaunay2D::GenerateEdges(const SInt chunk_row, const SInt chunk_column) {
     SInt chunk_id = Encode(chunk_column, chunk_row);
 

--- a/kagen/generators/geometric/delaunay/delaunay_2d.h
+++ b/kagen/generators/geometric/delaunay/delaunay_2d.h
@@ -16,8 +16,6 @@ class Delaunay2D : public Geometric2D {
 public:
     Delaunay2D(const PGeneratorConfig& config, PEID rank, PEID size);
 
-    bool IsAlmostUndirected() const override;
-
 protected:
     static constexpr SInt COPY_FLAG = SInt(1) << (sizeof(SInt) * CHAR_BIT - 1);
 

--- a/kagen/generators/geometric/rgg.cpp
+++ b/kagen/generators/geometric/rgg.cpp
@@ -117,11 +117,10 @@ PGeneratorConfig NormalizeParametersCommon(
 }
 } // namespace
 
-int RGG2DFactory::Requirements() const {
-    return GeneratorRequirement::SQUARE_CHUNKS | GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE;
-}
+PGeneratorConfig RGG2DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureSquareChunkSize(config, size);
+    EnsurePowerOfTwoCommunicatorSize(config, size);
 
-PGeneratorConfig RGG2DFactory::NormalizeParameters(PGeneratorConfig config, const bool output) const {
     return NormalizeParametersCommon(config, &ApproxRadius2D, &ApproxNumNodes2D, output);
 }
 
@@ -130,11 +129,10 @@ RGG2DFactory::Create(const PGeneratorConfig& config, const PEID rank, const PEID
     return std::make_unique<RGG2D>(config, rank, size);
 }
 
-int RGG3DFactory::Requirements() const {
-    return GeneratorRequirement::CUBIC_CHUNKS | GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE;
-}
+PGeneratorConfig RGG3DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureCubicChunkSize(config, size);
+    EnsurePowerOfTwoCommunicatorSize(config, size);
 
-PGeneratorConfig RGG3DFactory::NormalizeParameters(PGeneratorConfig config, const bool output) const {
     return NormalizeParametersCommon(config, &ApproxRadius3D, &ApproxNumNodes3D, output);
 }
 

--- a/kagen/generators/geometric/rgg.h
+++ b/kagen/generators/geometric/rgg.h
@@ -7,18 +7,14 @@
 namespace kagen {
 class RGG2DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };
 
 class RGG3DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/graph500_generator.h
+++ b/kagen/generators/graph500_generator.h
@@ -7,7 +7,9 @@
 namespace kagen {
 class Graph500Generator : public Generator {
 public:
-    Graph500Generator(const PGeneratorConfig& config_, MPI_Comm comm);
+    Graph500Generator(const PGeneratorConfig& config);
+
+    void Finalize(MPI_Comm comm) final;
 
 protected:
     inline void PushLocalEdge(const int from, const int to) {
@@ -19,11 +21,8 @@ protected:
         }
     }
 
-    void DistributeRoundRobin(SInt n);
-
 private:
     const PGeneratorConfig&           config_;
-    MPI_Comm                          comm_;
     std::vector<std::tuple<int, int>> local_edges_;
 };
 } // namespace kagen

--- a/kagen/generators/grid/grid_2d.cpp
+++ b/kagen/generators/grid/grid_2d.cpp
@@ -6,11 +6,9 @@
 #include "kagen/generators/grid/grid_2d.h"
 
 namespace kagen {
-int Grid2DFactory::Requirements() const {
-    return GeneratorRequirement::SQUARE_CHUNKS;
-}
+PGeneratorConfig Grid2DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureSquareChunkSize(config, size);
 
-PGeneratorConfig Grid2DFactory::NormalizeParameters(PGeneratorConfig config, bool output) const {
     if (config.p == 0) {
         if (config.grid_x == 0 || config.grid_y == 0 || config.m == 0) {
             throw ConfigurationError("at least two parameters out of {(x, y), m, p} must be nonzero");

--- a/kagen/generators/grid/grid_2d.h
+++ b/kagen/generators/grid/grid_2d.h
@@ -15,9 +15,7 @@
 namespace kagen {
 class Grid2DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/grid/grid_3d.cpp
+++ b/kagen/generators/grid/grid_3d.cpp
@@ -4,16 +4,14 @@
 #include "kagen/generators/grid/grid_3d.h"
 
 namespace kagen {
-int Grid3DFactory::Requirements() const {
-    return GeneratorRequirement::CUBIC_CHUNKS;
-}
-
 std::unique_ptr<Generator>
 Grid3DFactory::Create(const PGeneratorConfig& config, const PEID rank, const PEID size) const {
     return std::make_unique<Grid3D>(config, rank, size);
 }
 
-PGeneratorConfig Grid3DFactory::NormalizeParameters(PGeneratorConfig config, bool output) const {
+PGeneratorConfig Grid3DFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    EnsureCubicChunkSize(config, size);
+
     if (config.p == 0) {
         if (config.grid_x == 0 || config.grid_y == 0 || config.grid_z == 0 || config.m == 0) {
             throw ConfigurationError("at least two parameters out of {(x, y, z), m, p} must be nonzero");

--- a/kagen/generators/grid/grid_3d.h
+++ b/kagen/generators/grid/grid_3d.h
@@ -15,9 +15,7 @@
 namespace kagen {
 class Grid3DFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/hyperbolic/hyperbolic.cpp
+++ b/kagen/generators/hyperbolic/hyperbolic.cpp
@@ -7,11 +7,13 @@
 #include <iostream>
 
 namespace kagen {
-int HyperbolicFactory::Requirements() const {
-    return GeneratorRequirement::POWER_OF_TWO_COMMUNICATOR_SIZE;
-}
+PGeneratorConfig
+HyperbolicFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
+    if (config.k == 0) {
+        config.k = static_cast<SInt>(size);
+    }
+    EnsurePowerOfTwoCommunicatorSize(config, size);
 
-PGeneratorConfig HyperbolicFactory::NormalizeParameters(PGeneratorConfig config, const bool output) const {
     if (config.avg_degree == 0) {
         if (config.m == 0 || config.n == 0) {
             throw ConfigurationError("at least two parameters out of {n, m, d} must be nonzero");

--- a/kagen/generators/hyperbolic/hyperbolic.cpp
+++ b/kagen/generators/hyperbolic/hyperbolic.cpp
@@ -2,6 +2,7 @@
 
 #include "kagen/context.h"
 #include "kagen/generators/generator.h"
+#include "kagen/tools/postprocessor.h"
 
 #include <csignal>
 #include <iostream>
@@ -116,8 +117,8 @@ Hyperbolic<Double>::Hyperbolic(const PGeneratorConfig& config, const PEID rank, 
 }
 
 template <typename Double>
-bool Hyperbolic<Double>::IsAlmostUndirected() const {
-    return true;
+void Hyperbolic<Double>::Finalize(MPI_Comm comm) {
+    AddReverseEdges(edges_, vertex_range_, comm);
 }
 
 template <typename Double>

--- a/kagen/generators/hyperbolic/hyperbolic.h
+++ b/kagen/generators/hyperbolic/hyperbolic.h
@@ -25,9 +25,7 @@
 namespace kagen {
 class HyperbolicFactory : public GeneratorFactory {
 public:
-    int Requirements() const override;
-
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };

--- a/kagen/generators/hyperbolic/hyperbolic.h
+++ b/kagen/generators/hyperbolic/hyperbolic.h
@@ -13,6 +13,8 @@
 #include <tuple>
 #include <vector>
 
+#include <mpi.h>
+
 #include "hash.hpp"
 #include "kagen/context.h"
 #include "kagen/definitions.h"
@@ -44,7 +46,7 @@ public:
 
     Hyperbolic(const PGeneratorConfig& config, PEID rank, PEID size);
 
-    bool IsAlmostUndirected() const override;
+    void Finalize(MPI_Comm comm) final;
 
 protected:
     void GenerateImpl() override;

--- a/kagen/generators/kronecker/kronecker.cpp
+++ b/kagen/generators/kronecker/kronecker.cpp
@@ -41,7 +41,7 @@ KroneckerFactory::Create(const PGeneratorConfig& config, const PEID rank, const 
 }
 
 Kronecker::Kronecker(const PGeneratorConfig& config, const PEID rank, const PEID size)
-    : Graph500Generator(config, MPI_COMM_WORLD), // @todo
+    : Graph500Generator(config),
       config_(config),
       size_(size),
       rank_(rank) {
@@ -79,8 +79,6 @@ void Kronecker::GenerateImpl() {
         mrg_skip(&new_state, 0, (uint64_t)i, 0);
         GenerateEdge(config_.n, 0, &new_state);
     }
-
-    DistributeRoundRobin(config_.n);
 }
 
 int Kronecker::Bernoulli(mrg_state* st, int level, int nlevels) {

--- a/kagen/generators/rmat/rmat.cpp
+++ b/kagen/generators/rmat/rmat.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<Generator> RMATFactory::Create(const PGeneratorConfig& config, c
 }
 
 RMAT::RMAT(const PGeneratorConfig& config, const PEID rank, const PEID size)
-    : Graph500Generator(config, MPI_COMM_WORLD), // @todo
+    : Graph500Generator(config),
       config_(config),
       rank_(rank) {
     const SInt edges_per_pe    = config_.m / size;
@@ -53,7 +53,6 @@ void RMAT::GenerateImpl() {
 
     const SInt seed  = rank_ + 1;
     const SInt log_n = std::log2(config_.n);
-    const SInt n     = 1ull << log_n;
     const SInt depth = std::min<SInt>(9, log_n);
 
     RNG  gen(seed);
@@ -63,7 +62,5 @@ void RMAT::GenerateImpl() {
 
     // Generate local edges
     r.get_edges([&](const auto u, const auto v) { PushLocalEdge(u, v); }, num_edges_, gen);
-
-    DistributeRoundRobin(n);
 }
 } // namespace kagen

--- a/kagen/generators/rmat/rmat.cpp
+++ b/kagen/generators/rmat/rmat.cpp
@@ -9,7 +9,7 @@
 #include <mpi.h>
 
 namespace kagen {
-PGeneratorConfig RMATFactory::NormalizeParameters(PGeneratorConfig config, bool output) const {
+PGeneratorConfig RMATFactory::NormalizeParameters(PGeneratorConfig config, const PEID size, const bool output) const {
     if (config.rmat_a < 0 || config.rmat_b < 0 || config.rmat_b < 0) {
         throw ConfigurationError("probabilities may not be negative");
     }
@@ -25,6 +25,10 @@ PGeneratorConfig RMATFactory::NormalizeParameters(PGeneratorConfig config, bool 
     if (output && config.n != 1ull << log_n) {
         std::cout << "Warning: generator requires the number of vertices to be a power of two" << std::endl;
         std::cout << "  Changing the number of vertices to " << (1ull << log_n) << std::endl;
+    }
+
+    if (config.k == 0) {
+        config.k = static_cast<SInt>(size);
     }
 
     return config;

--- a/kagen/generators/rmat/rmat.h
+++ b/kagen/generators/rmat/rmat.h
@@ -7,7 +7,7 @@
 namespace kagen {
 class RMATFactory : public GeneratorFactory {
 public:
-    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, bool output) const override;
+    PGeneratorConfig NormalizeParameters(PGeneratorConfig config, PEID size, bool output) const override;
 
     std::unique_ptr<Generator> Create(const PGeneratorConfig& config, PEID rank, PEID size) const override;
 };


### PR DESCRIPTION
Move more parameter setup / validation / postprocessing to the generators (previously took place in `facade.cpp`)
Now allows Kronecker / RMAT generators to be used with non-MPI_COMM_WORLD communicators (was hardcoded previously) 