### PR TITLE
csr fix for loading metis files

### DIFF
--- a/kagen/generators/static/static_graph.cpp
+++ b/kagen/generators/static/static_graph.cpp
@@ -68,6 +68,8 @@ void StaticGraph::GenerateImpl(const GraphRepresentation representation) {
 
     auto graph      = reader->Read(from, to_node, to_edge, representation);
     vertex_range_   = graph.vertex_range;
+    xadj_           = std::move(graph.xadj);
+    adjncy_         = std::move(graph.adjncy);
     edges_          = std::move(graph.edges);
     edge_weights_   = std::move(graph.edge_weights);
     vertex_weights_ = std::move(graph.vertex_weights);


### PR DESCRIPTION
This fixes a bug that occured when using kagen as a library and reading metis files (GenerateFromOptionString) with CSR representation. The resulting graphs xadj and adjncy were empty.

Example:
KaGen gen(MPI_COMM_WORLD);
gen.UseCSRRepresentation();
KaGenResult graph = gen.GenerateFromOptionString("static;filename=\<filepath\>;input_format=metis;distribution=balance-vertices");