### PR TITLE
Do not use `constexpr` in header if C++ < 17 is used.

### DIFF
--- a/library/kagen.h
+++ b/library/kagen.h
@@ -92,12 +92,7 @@ struct KaGenResult {
 private:
     template <typename To, typename From>
     std::vector<To> TakeVector(From& from) {
-    // without this, we can not include this header in code using < C++17
-#if __cplusplus >= 201703L
-        if constexpr (std::is_same_v<typename From::value_type, To>) {
-#else
         if (std::is_same<typename From::value_type, To>::value) {
-#endif
             return std::move(from);
         }
 

--- a/library/kagen.h
+++ b/library/kagen.h
@@ -92,9 +92,15 @@ struct KaGenResult {
 private:
     template <typename To, typename From>
     std::vector<To> TakeVector(From& from) {
+    // without this, we can not include this header in code using < C++17
+#if __cplusplus >= 201703L
         if constexpr (std::is_same_v<typename From::value_type, To>) {
+#else
+        if (std::is_same<typename From::value_type, To>::value) {
+#endif
             return std::move(from);
         }
+
 
         std::vector<To> copy(from.size());
         std::copy(from.begin(), from.end(), copy.begin());

--- a/library/kagen.h
+++ b/library/kagen.h
@@ -101,7 +101,6 @@ private:
             return std::move(from);
         }
 
-
         std::vector<To> copy(from.size());
         std::copy(from.begin(), from.end(), copy.begin());
         std::vector<typename From::value_type> free;


### PR DESCRIPTION
The current CMake setup does not enforce C++17 for dependents, but this prevented users from including KaGen in their C++14 code base.