### PR TITLE
Represent edgelists as vectors of pairs instead of tuples.

### DIFF
--- a/kagen/definitions.h
+++ b/kagen/definitions.h
@@ -38,7 +38,7 @@ constexpr PEID ROOT = 0;
 
 enum Direction { Up, Down, Left, Right, Front, Back };
 
-using EdgeList    = std::vector<std::tuple<SInt, SInt>>;
+using EdgeList    = std::vector<std::pair<SInt, SInt>>;
 using VertexRange = std::pair<SInt, SInt>;
 
 using Coordinates2D = std::vector<std::tuple<HPFloat, HPFloat>>;

--- a/kagen/tools/postprocessor.cpp
+++ b/kagen/tools/postprocessor.cpp
@@ -119,8 +119,8 @@ void AddReverseEdgesAndRedistribute(EdgeList& edge_list, const VertexRange verte
     const auto to     = ranges[rank].second;
 
     // Create new edge arrays
-    std::vector<std::tuple<SInt, SInt>>              local_edges;
-    std::vector<std::vector<std::tuple<SInt, SInt>>> remote_edges(size);
+    std::vector<std::pair<SInt, SInt>>              local_edges;
+    std::vector<std::vector<std::pair<SInt, SInt>>> remote_edges(size);
     for (const auto& [u, v]: edge_list) {
         if (u == v) { // Ignore self loops
             continue;

--- a/library/kagen.h
+++ b/library/kagen.h
@@ -23,7 +23,7 @@ enum class GraphRepresentation;
 
 using SInt          = unsigned long long;
 using SSInt         = long long;
-using EdgeList      = std::vector<std::tuple<SInt, SInt>>;
+using EdgeList      = std::vector<std::pair<SInt, SInt>>;
 using VertexRange   = std::pair<SInt, SInt>;
 using PEID          = int;
 using HPFloat       = long double;
@@ -50,8 +50,8 @@ struct KaGenResult {
           coordinates_3d(std::move(std::get<6>(result).second)) {}
 
     template <typename T = SInt>
-    std::vector<std::tuple<T, T>> TakeEdges() {
-        return TakeVector<std::tuple<T, T>>(edges);
+    std::vector<std::pair<T, T>> TakeEdges() {
+        return TakeVector<std::pair<T, T>>(edges);
     }
 
     template <typename T = SInt>


### PR DESCRIPTION
This makes them easier to work with.